### PR TITLE
Support setting location for user

### DIFF
--- a/plugins/location.go
+++ b/plugins/location.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"git.icyphox.sh/paprika/plugins/location"
 	"gopkg.in/irc.v3"
 )
 
@@ -20,8 +21,15 @@ func (Location) Triggers() []string {
 func (Location) Execute(m *irc.Message) (string, error) {
 	parsed := strings.SplitN(m.Trailing(), " ", 2)
 	trigger := parsed[0]
-	location := parsed[1]
 	if len(parsed) != 2 {
 		return fmt.Sprintf("Usage: %s <location>", trigger), nil
 	}
+	loc := parsed[1]
+
+	err := location.SetLocation(loc, m.Prefix.Name)
+	if err != nil {
+		return "Error setting location", err
+	}
+
+	return "Successfully set location", nil
 }

--- a/plugins/location.go
+++ b/plugins/location.go
@@ -1,0 +1,27 @@
+package plugins
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/irc.v3"
+)
+
+func init() {
+	Register(Location{})
+}
+
+type Location struct{}
+
+func (Location) Triggers() []string {
+	return []string{".loc", ".location"}
+}
+
+func (Location) Execute(m *irc.Message) (string, error) {
+	parsed := strings.SplitN(m.Trailing(), " ", 2)
+	trigger := parsed[0]
+	location := parsed[1]
+	if len(parsed) != 2 {
+		return fmt.Sprintf("Usage: %s <location>", trigger), nil
+	}
+}

--- a/plugins/location/geocode.go
+++ b/plugins/location/geocode.go
@@ -1,4 +1,4 @@
-package weather
+package location
 
 import (
 	"encoding/json"

--- a/plugins/location/location.go
+++ b/plugins/location/location.go
@@ -1,0 +1,25 @@
+package location
+
+import (
+	"fmt"
+
+	"git.icyphox.sh/paprika/database"
+)
+
+func SetLocation(loc, nick string) error {
+	err := database.DB.Set(
+		[]byte(fmt.Sprintf("loc/%s", nick)),
+		[]byte(loc),
+	)
+
+	return err
+}
+
+func GetLocation(nick string) (string, error) {
+	loc, err := database.DB.Get([]byte(fmt.Sprintf("loc/%s", nick)))
+	if err != nil {
+		return "", err
+	}
+
+	return string(loc), nil
+}

--- a/plugins/weather.go
+++ b/plugins/weather.go
@@ -1,10 +1,11 @@
 package plugins
 
 import (
-	"fmt"
 	"strings"
 
+	"git.icyphox.sh/paprika/plugins/location"
 	"git.icyphox.sh/paprika/plugins/weather"
+	"github.com/dgraph-io/badger/v3"
 	"gopkg.in/irc.v3"
 )
 
@@ -23,15 +24,42 @@ func (Weather) Triggers() []string {
 
 func (Weather) Execute(m *irc.Message) (string, error) {
 	parsed := strings.SplitN(m.Trailing(), " ", 2)
+	var loc string
 	if len(parsed) != 2 {
-		return fmt.Sprintf("Usage: %s <location>", parsed[0]), nil
-	}
-	query := parsed[1]
-	li, err := weather.GetLocationInfo(query)
-	if err != nil {
-		return "Error getting location info", err
+		var err error
+		// Check if they've already set their location
+		loc, err = location.GetLocation(m.Prefix.Name)
+		if err == badger.ErrKeyNotFound {
+			return "Location not set. Use '.loc <location>' to set it.", nil
+		} else if err != nil {
+			return "Error getting location", err
+		}
 	}
 
+	// They're either querying for a location or @nick.
+	if len(loc) == 0 {
+		if strings.HasPrefix(parsed[1], "@") {
+			// Strip '@'
+			var err error
+			loc, err = location.GetLocation(parsed[1][1:])
+			if err == badger.ErrKeyNotFound {
+				return "Location not set. Use '.loc <location>' to set it.", nil
+			} else if err != nil {
+				return "Error getting location. Try again.", err
+			}
+		} else {
+			loc = parsed[1]
+		}
+	}
+
+	li, err := location.GetLocationInfo(loc)
+	if err != nil {
+		return "Error getting location info. Try again.", err
+	}
+
+	if len(li.Features) == 0 {
+		return "Error getting location info. Try again.", nil
+	}
 	coordinates := li.Features[0].Geometry.Coordinates
 	label := li.Features[0].Properties.Geocoding.Label
 	info, err := weather.GetWeather(coordinates, label)


### PR DESCRIPTION
This patch adds support for setting a location for a user using `.loc <location>`, and integrates this into the weather plugin. In practice, this looks like so:

```
<foo> .loc Fooland
<foo> .w
<paprika> <prints weather in Fooland>
<foo> .w @bar
<paprika> <prints weather at bar's configured location>
```